### PR TITLE
s64ilp32: ebpf_jit: Fix some cases of test_bpf that cannot be executed by BPF_JIT

### DIFF
--- a/arch/riscv/net/bpf_jit_comp64.c
+++ b/arch/riscv/net/bpf_jit_comp64.c
@@ -473,7 +473,7 @@ static int emit_call(u64 addr, bool fixed_addr, struct rv_jit_context *ctx)
 		 * Use the ro_insns(RX) to calculate the offset as the BPF
 		 * program will finally run from this memory region.
 		 */
-		ip = (u64)(long)(ctx->ro_insns + ctx->ninsns);
+		ip = (u64)(unsigned long)(ctx->ro_insns + ctx->ninsns);
 		off = addr - ip;
 	}
 


### PR DESCRIPTION
```
test_bpf: #6 LD_IND
bpf-jit: target offset 0x10872ffce is out of range jited:0 2164 1381 1477 PASS
test_bpf: Summary: 1 PASSED, 0 FAILED, [0/1 JIT'ed]
```