### PR TITLE
riscv: build: Support compiling kernel using Xuantie toolchain

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -518,8 +518,6 @@ config TOOLCHAIN_HAS_V
 	default y
 	depends on !64BIT || $(cc-option,-mabi=lp64 -march=rv64iv)
 	depends on !32BIT || $(cc-option,-mabi=ilp32 -march=rv32iv)
-	depends on LLD_VERSION >= 140000 || LD_VERSION >= 23800
-	depends on AS_HAS_OPTION_ARCH
 
 config RISCV_ISA_V
 	bool "VECTOR extension support"

--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -72,9 +72,8 @@ endif
 # Check if the toolchain supports Zihintpause extension
 riscv-march-$(CONFIG_TOOLCHAIN_HAS_ZIHINTPAUSE) := $(riscv-march-y)_zihintpause
 
-# Remove F,D,V from isa string for all. Keep extensions between "fd" and "v" by
-# matching non-v and non-multi-letter extensions out with the filter ([^v_]*)
-KBUILD_CFLAGS += -march=$(shell echo $(riscv-march-y) | sed -E 's/(rv32ima|rv64ima)fd([^v_]*)v?/\1\2/')
+# Remove F,D from isa string for all.
+KBUILD_CFLAGS += -march=$(subst fd,,$(riscv-march-y))
 
 KBUILD_AFLAGS += -march=$(riscv-march-y)
 


### PR DESCRIPTION
Compared to toolchains with gcc12 or above, the Xuantie toolchain gcc10 does not have vector support enabled by default, and -march needs to be explicitly specified.

1. Xuantie toolchain gcc10 does not support using AS_HAS_OPTION_ARCH to automatically detect vector extensions and enable it.
2. The ld tool version of Xuantie toolchain gcc10 is 2.35, which is less than the 2.38 required by TOOLCHAIN_HAS_V.