### PR TITLE
s64ilp32: ebpf_jit: Fix the incorrect jump addresses and index offsets in tail_call

### DIFF
--- a/arch/riscv/net/bpf_jit_comp64.c
+++ b/arch/riscv/net/bpf_jit_comp64.c
@@ -366,12 +366,20 @@ static int emit_bpf_tail_call(int insn, struct rv_jit_context *ctx)
 	 * if (!prog)
 	 *     goto out;
 	 */
+#ifdef CONFIG_ARCH_RV64ILP32
+	emit_slli(RV_REG_T2, RV_REG_A2, 2, ctx);
+#else
 	emit_slli(RV_REG_T2, RV_REG_A2, 3, ctx);
+#endif
 	emit_add(RV_REG_T2, RV_REG_T2, RV_REG_A1, ctx);
 	off = offsetof(struct bpf_array, ptrs);
 	if (is_12b_check(off, insn))
 		return -1;
+#ifdef CONFIG_ARCH_RV64ILP32
+	emit_lw(RV_REG_T2, off, RV_REG_T2, ctx);
+#else
 	emit_ld(RV_REG_T2, off, RV_REG_T2, ctx);
+#endif
 	off = ninsns_rvoff(tc_ninsn - (ctx->ninsns - start_insn));
 	emit_branch(BPF_JEQ, RV_REG_T2, RV_REG_ZERO, off, ctx);
 
@@ -379,7 +387,11 @@ static int emit_bpf_tail_call(int insn, struct rv_jit_context *ctx)
 	off = offsetof(struct bpf_prog, bpf_func);
 	if (is_12b_check(off, insn))
 		return -1;
+#ifdef CONFIG_ARCH_RV64ILP32
+	emit_lw(RV_REG_T3, off, RV_REG_T2, ctx);
+#else
 	emit_ld(RV_REG_T3, off, RV_REG_T2, ctx);
+#endif
 	__build_epilogue(true, ctx);
 	return 0;
 }


### PR DESCRIPTION
This patch solves the 10 tail_call testing issues in test_bpf. At this point, all tests of test_bpf in BPF_JIT mode have passed. Here is the comparison between s64ilp32, s64lp64 and s32ilp32:

- s64lp64

```
...
test_bpf: Summary: 1026 PASSED, 0 FAILED, [1014/1014 JIT'ed]
test_bpf: #0 Tail call leaf jited:1 188 PASS
test_bpf: #1 Tail call 2 jited:1 180 PASS
test_bpf: #2 Tail call 3 jited:1 203 PASS
test_bpf: #3 Tail call 4 jited:1 225 PASS
test_bpf: #4 Tail call load/store leaf jited:1 145 PASS
test_bpf: #5 Tail call load/store jited:1 195 PASS
test_bpf: #6 Tail call error path, max count reached jited:1 997 PASS
test_bpf: #7 Tail call count preserved across function calls jited:1 155563 PASS
test_bpf: #8 Tail call error path, NULL target jited:1 164 PASS
test_bpf: #9 Tail call error path, index out of range jited:1 136 PASS
test_bpf: test_tail_calls: Summary: 10 PASSED, 0 FAILED, [10/10 JIT'ed]
...
test_bpf: test_skb_segment: Summary: 2 PASSED, 0 FAILED
```

- s64ilp32

```
...
test_bpf: Summary: 1026 PASSED, 0 FAILED, [1014/1014 JIT'ed]
test_bpf: #0 Tail call leaf jited:1 160 PASS
test_bpf: #1 Tail call 2 jited:1 221 PASS
test_bpf: #2 Tail call 3 jited:1 251 PASS
test_bpf: #3 Tail call 4 jited:1 275 PASS
test_bpf: #4 Tail call load/store leaf jited:1 198 PASS
test_bpf: #5 Tail call load/store jited:1 262 PASS
test_bpf: #6 Tail call error path, max count reached jited:1 1390 PASS
test_bpf: #7 Tail call count preserved across function calls jited:1 204492 PASS
test_bpf: #8 Tail call error path, NULL target jited:1 199 PASS
test_bpf: #9 Tail call error path, index out of range jited:1 168 PASS
test_bpf: test_tail_calls: Summary: 10 PASSED, 0 FAILED, [10/10 JIT'ed]
...
test_bpf: test_skb_segment: Summary: 2 PASSED, 0 FAILED
```

- s32ilp32

```
...
test_bpf: Summary: 1027 PASSED, 0 FAILED, [832/1015 JIT'ed]
test_bpf: #0 Tail call leaf jited:1 266 PASS
test_bpf: #1 Tail call 2 jited:1 409 PASS
test_bpf: #2 Tail call 3 jited:1 481 PASS
test_bpf: #3 Tail call 4 jited:1 537 PASS
test_bpf: #4 Tail call load/store leaf jited:1 325 PASS
test_bpf: #5 Tail call load/store jited:1 427 PASS
test_bpf: #6 Tail call error path, max count reached jited:1 3050 PASS
test_bpf: #7 Tail call count preserved across function calls jited:1 255522 PASS
test_bpf: #8 Tail call error path, NULL target jited:1 315 PASS
test_bpf: #9 Tail call error path, index out of range jited:1 280 PASS
test_bpf: test_tail_calls: Summary: 10 PASSED, 0 FAILED, [10/10 JIT'ed]
...
test_bpf: test_skb_segment: Summary: 2 PASSED, 0 FAILED
```

Actually, s64ilp32 and s64lp64 perform consistently, both in terms of the number that can be executed by JIT and execution time. while, only 80% of cases in s32ilp32 can be executed by JIT, and the execution time is also longer under the same JIT execution situation.