### PR TITLE
riscv: mm: support icache&tlb HW broadcast on xuantie

### DIFF
--- a/arch/riscv/mm/tlbflush.c
+++ b/arch/riscv/mm/tlbflush.c
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0
 
+#include <linux/of.h>
 #include <linux/mm.h>
 #include <linux/smp.h>
 #include <linux/sched.h>
 #include <asm/sbi.h>
 #include <asm/mmu_context.h>
+
+static u32 xuantie_flush_tlb_range_flag = 0;
 
 static inline void local_flush_tlb_all_asid(unsigned long asid)
 {
@@ -48,10 +51,14 @@ static void __ipi_flush_tlb_all(void *info)
 
 void flush_tlb_all(void)
 {
-	if (riscv_use_ipi_for_rfence())
-		on_each_cpu(__ipi_flush_tlb_all, NULL, 1);
-	else
-		sbi_remote_sfence_vma(NULL, 0, -1);
+	if (xuantie_flush_tlb_range_flag) {
+		__asm__ __volatile__ ("sfence.vma" : : : "memory");
+	} else {
+		if (riscv_use_ipi_for_rfence())
+			on_each_cpu(__ipi_flush_tlb_all, NULL, 1);
+		else
+			sbi_remote_sfence_vma(NULL, 0, -1);
+	}
 }
 
 struct flush_tlb_range_data {
@@ -129,18 +136,49 @@ static void __flush_tlb_range(struct mm_struct *mm, unsigned long start,
 
 void flush_tlb_mm(struct mm_struct *mm)
 {
-	__flush_tlb_range(mm, 0, -1, PAGE_SIZE);
+	if (xuantie_flush_tlb_range_flag) {
+		unsigned long asid = atomic_long_read(&mm->context.id) & asid_mask;
+		__asm__ __volatile__ ("sfence.vma zero, %0"
+					:
+					: "r"(asid)
+					: "memory");
+	} else {
+		__flush_tlb_range(mm, 0, -1, PAGE_SIZE);
+	}
 }
 
 void flush_tlb_page(struct vm_area_struct *vma, unsigned long addr)
 {
-	__flush_tlb_range(vma->vm_mm, addr, PAGE_SIZE, PAGE_SIZE);
+	if (xuantie_flush_tlb_range_flag) {
+		unsigned long asid = atomic_long_read(&vma->vm_mm->context.id) & asid_mask;
+		addr &= PAGE_MASK;
+		__asm__ __volatile__ ("sfence.vma %0, %1"
+					:
+					: "r"(addr), "r"(asid)
+					: "memory");
+	} else {
+		__flush_tlb_range(vma->vm_mm, addr, PAGE_SIZE, PAGE_SIZE);
+	}
 }
 
 void flush_tlb_range(struct vm_area_struct *vma, unsigned long start,
 		     unsigned long end)
 {
-	__flush_tlb_range(vma->vm_mm, start, end - start, PAGE_SIZE);
+	if (xuantie_flush_tlb_range_flag) {
+		unsigned long asid = atomic_long_read(&vma->vm_mm->context.id) & asid_mask;
+		start &= PAGE_MASK;
+		end   += PAGE_SIZE - 1;
+		end   &= PAGE_MASK;
+		while (start < end) {
+			__asm__ __volatile__ ("sfence.vma %0, %1"
+						:
+						: "r"(start), "r"(asid)
+						: "memory");
+			start += PAGE_SIZE;
+		}
+	} else {
+		__flush_tlb_range(vma->vm_mm, start, end - start, PAGE_SIZE);
+	}
 }
 #ifdef CONFIG_TRANSPARENT_HUGEPAGE
 void flush_pmd_tlb_range(struct vm_area_struct *vma, unsigned long start,
@@ -149,3 +187,15 @@ void flush_pmd_tlb_range(struct vm_area_struct *vma, unsigned long start,
 	__flush_tlb_range(vma->vm_mm, start, end - start, PMD_SIZE);
 }
 #endif
+
+static int __init xuantie_flush_tlb_init(void)
+{
+	struct device_node *cpu = of_find_node_by_path("/cpus");
+	if (cpu) {
+		of_property_read_u32(cpu, "flush-tlb-range", &xuantie_flush_tlb_range_flag);
+		of_node_put(cpu);
+	}
+
+	return 0;
+}
+arch_initcall(xuantie_flush_tlb_init);


### PR DESCRIPTION
By configuring `flush-tlb-range` and `flush-icache-range` in DTS to enable the HW broadcast feature of Xuantie CPU, soft broadcasting is avoided and system performance is improved.

The DTS example as follows:
```
cpus {
    ...
    flush-icache-range = <1>;
    flush-tlb-range = <1>;
    cpu@0 {
    ...
```