### PR TITLE
riscv:build: Fix build with gcc-14

### DIFF
--- a/arch/riscv/Makefile
+++ b/arch/riscv/Makefile
@@ -47,8 +47,6 @@ riscv-march-aflags-$(CONFIG_ARCH_RV32I)		:= rv32ima
 riscv-march-aflags-$(CONFIG_ARCH_RV64I)		:= rv64ima
 riscv-march-aflags-$(CONFIG_FPU)		:= $(riscv-march-aflags-y)fd
 riscv-march-aflags-$(CONFIG_RISCV_ISA_C)	:= $(riscv-march-aflags-y)c
-riscv-march-aflags-$(CONFIG_VECTOR_1_0)		:= $(riscv-march-aflags-y)v
-riscv-march-aflags-$(CONFIG_VECTOR_0_7)		:= $(riscv-march-aflags-y)v0p7
 riscv-march-aflags-$(CONFIG_THEAD_ISA)		:= $(riscv-march-aflags-y)_xtheadc
 
 KBUILD_CFLAGS += -march=$(riscv-march-cflags-y) -Wa,-march=$(riscv-march-aflags-y)

--- a/arch/riscv/kernel/Makefile
+++ b/arch/riscv/kernel/Makefile
@@ -12,7 +12,11 @@ endif
 ifdef CONFIG_KEXEC
 AFLAGS_kexec_relocate.o := -mcmodel=medany $(call cc-option,-mno-relax)
 endif
-
+ifdef CONFIG_VECTOR_1_0
+AFLAGS_vector.o := $(subst rv64ima,rv64imav,$(KBUILD_AFLAGS))
+else
+AFLAGS_vector.o := $(subst rv64ima,rv64imav0p7,$(KBUILD_AFLAGS))
+endif
 extra-y += head.o
 extra-y += vmlinux.lds
 


### PR DESCRIPTION
Only enable vector instructions when compiling vector.s to avoid the impact of automatic vectorization.