### PR TITLE
irqchip: Add a XuanTie PLIC driver

### DIFF
--- a/drivers/irqchip/irq-sifive-plic.c
+++ b/drivers/irqchip/irq-sifive-plic.c
@@ -400,3 +400,4 @@ out_free_priv:
 
 IRQCHIP_DECLARE(sifive_plic, "sifive,plic-1.0.0", plic_init);
 IRQCHIP_DECLARE(riscv_plic0, "riscv,plic0", plic_init); /* for legacy systems */
+IRQCHIP_DECLARE(thead_plic, "thead,c900-plic", plic_init);


### PR DESCRIPTION
Add a driver for the XuanTie implementation of the RISC-V Platform Level Interrupt Controller (PLIC).