### PR TITLE
riscv: use CSR_SATP instead of the legacy sptbr name in switch_mm

### DIFF
--- a/arch/riscv/mm/context.c
+++ b/arch/riscv/mm/context.c
@@ -64,7 +64,7 @@ void switch_mm(struct mm_struct *prev, struct mm_struct *next,
 	asid = (next->context.asid.counter & SATP_ASID_MASK)
 		<< SATP_ASID_SHIFT;
 
-	csr_write(sptbr, virt_to_pfn(next->pgd) | SATP_MODE | asid);
+	csr_write(CSR_SATP, virt_to_pfn(next->pgd) | SATP_MODE | asid);
 #endif
 
 	flush_icache_deferred(next);


### PR DESCRIPTION
Switch to our own constant for the satp register instead of using the old name from a legacy version of the privileged spec.